### PR TITLE
refactor: move safe_get to utils/http.py

### DIFF
--- a/src/sleeper_api.py
+++ b/src/sleeper_api.py
@@ -1,34 +1,7 @@
-import requests
-from time import sleep
-import random
 from typing import List
 from pydantic import ValidationError
 from src.models import SleeperUser, SleeperLeague
-
-MAX_RETRIES = 3
-BASE_DELAY = 1  # in seconds
-MAX_DELAY = 10  # max delay between retries
-HEADERS = {
-    "User-Agent": "TradeWindsDefinitelyNotABot/0.1 (Sleeper: @raichusaurus)"
-}
-
-def safe_get(url: str) -> dict:
-    for attempt in range(1, MAX_RETRIES + 1):
-        try:
-            response = requests.get(url, headers=HEADERS)
-            response.raise_for_status()
-            return response.json()
-        except requests.HTTPError as e:
-            print(f"⚠️ Server error ({e.response.status_code}), retrying... [{attempt}/{MAX_RETRIES}]")
-        except requests.RequestException as e:
-            print(f"⚠️ Request failed ({e}), retrying... [{attempt}/{MAX_RETRIES}]")
-
-        # Exponential backoff with jitter
-        delay = min(BASE_DELAY * (2 ** (attempt - 1)), MAX_DELAY)
-        delay = delay * random.uniform(0.8, 1.2)  # add jitter
-        sleep(delay)
-
-    raise RuntimeError(f"❌ Failed to fetch data after {MAX_RETRIES} attempts: {url}")
+from src.utils.http import safe_get
 
 def get_user(username: str) -> str:
     url = f"https://api.sleeper.app/v1/user/{username}"

--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -1,0 +1,28 @@
+import requests
+from time import sleep
+import random
+
+MAX_RETRIES = 3
+BASE_DELAY = 1  # in seconds
+MAX_DELAY = 10  # max delay between retries
+HEADERS = {
+    "User-Agent": "TradeWindsDefinitelyNotABot/0.1 (Sleeper: @raichusaurus)"
+}
+
+def safe_get(url: str) -> dict:
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            response = requests.get(url, headers=HEADERS)
+            response.raise_for_status()
+            return response.json()
+        except requests.HTTPError as e:
+            print(f"⚠️ Server error ({e.response.status_code}), retrying... [{attempt}/{MAX_RETRIES}]")
+        except requests.RequestException as e:
+            print(f"⚠️ Request failed ({e}), retrying... [{attempt}/{MAX_RETRIES}]")
+
+        # Exponential backoff with jitter
+        delay = min(BASE_DELAY * (2 ** (attempt - 1)), MAX_DELAY)
+        delay = delay * random.uniform(0.8, 1.2)  # add jitter
+        sleep(delay)
+
+    raise RuntimeError(f"❌ Failed to fetch data after {MAX_RETRIES} attempts: {url}")


### PR DESCRIPTION
Create a src/utils/http.py module
Move safe_get() out of sleeper_api.py
Update imports in all places that use it
Confirm that MAX_RETRIES, headers, and jitter logic remain intact

Closes #1